### PR TITLE
Update main.yml to fix a deprecation warning

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Check Ubuntu version
   fail:
     msg: '{{ ansible_distribution_version }} is not an acceptable version of Ubuntu for this role'
-  when: ansible_distribution_version|version_compare(15.04, '<')
+  when: ansible_distribution_version is version_compare(15.04, '<')
 
 - name: Ensure old versions of Docker are not installed
   package:


### PR DESCRIPTION
[DEPRECATION WARNING]: Using tests as filters is deprecated. Instead of using 
`result|version_compare` instead use `result is version_compare`. This feature 
will be removed in version 2.9.